### PR TITLE
update UI interactions

### DIFF
--- a/src/components/claim-modal/claim-modal-buttons.tsx
+++ b/src/components/claim-modal/claim-modal-buttons.tsx
@@ -30,15 +30,17 @@ export const ClaimModalButtons = ({ disabled, reqBody }: ClaimModalButtonsProps)
       </DialogClose>
 
       {/* Confirm */}
-      <button
-        type='button'
-        disabled={disabled}
-        onClick={handleClaim}
-        className={`h-[37px] w-[87px] rounded-[10px] text-[16px] font-semibold text-white
-          ${disabled ? 'cursor-not-allowed bg-gray-500' : 'cursor-pointer bg-green-700 hover:bg-green-800'}`}
-      >
-        Confirm
-      </button>
+      <DialogClose>
+        <button
+          type='button'
+          disabled={disabled}
+          onClick={handleClaim}
+          className={`h-[37px] w-[87px] rounded-[10px] text-[16px] font-semibold text-white
+            ${disabled ? 'cursor-not-allowed bg-gray-500' : 'cursor-pointer bg-green-700 hover:bg-green-800'}`}
+        >
+          Confirm
+        </button>
+      </DialogClose>
     </div>
   );
 };

--- a/src/components/claim-modal/claim-modal-buttons.tsx
+++ b/src/components/claim-modal/claim-modal-buttons.tsx
@@ -1,3 +1,4 @@
+import { DialogClose } from '@/components/ui/dialog';
 import { authFetch } from '@/lib/api';
 import { ClaimPackageRequestBody } from '@/types';
 
@@ -18,13 +19,15 @@ export const ClaimModalButtons = ({ disabled, reqBody }: ClaimModalButtonsProps)
   return (
     <div className='flex h-full w-full items-center justify-end gap-4 p-[31px] pt-0'>
       {/* Cancel */}
-      <button
-        type='button'
-        className='cursor-pointer text-[16px] font-semibold text-black hover:text-gray-900 dark:text-white
-          dark:hover:text-gray-100'
-      >
-        Cancel
-      </button>
+      <DialogClose>
+        <button
+          type='button'
+          className='cursor-pointer text-[16px] font-semibold text-black hover:text-gray-900 dark:text-white
+            dark:hover:text-gray-100'
+        >
+          Cancel
+        </button>
+      </DialogClose>
 
       {/* Confirm */}
       <button

--- a/src/components/navbar/left-sidebar.tsx
+++ b/src/components/navbar/left-sidebar.tsx
@@ -21,23 +21,35 @@ const LeftSidebar = ({ className }: LeftSidebarProps) => {
     <div
       className={cn(
         `dark:bg-gray-1100 flex min-h-screen w-24 flex-col items-center justify-start gap-y-6 bg-gray-50 pt-30
-        dark:border dark:border-gray-700 [&>*]:transition-colors [&>*]:duration-300`,
+        dark:border dark:border-gray-700 [&>*]:transition-all [&>*]:duration-300 [&>*]:ease-out`,
         className,
       )}
     >
       {/* explore */}
       <LeftSidebarIcon title='Explore' selected={selected === 'Explore'} onClick={() => setSelected('Explore')}>
-        <MdOutlineExplore size={50} />
+        <MdOutlineExplore
+          size={50}
+          className='transition-transform duration-300 hover:scale-125 hover:drop-shadow-[0_0_8px_rgba(0,0,0,0.25)]
+            active:scale-95'
+        />
       </LeftSidebarIcon>
 
       {/* history */}
       <LeftSidebarIcon title='History' selected={selected === 'History'} onClick={() => setSelected('History')}>
-        <RiHistoryLine size={35} />
+        <RiHistoryLine
+          size={35}
+          className='transition-transform duration-300 hover:scale-125 hover:drop-shadow-[0_0_8px_rgba(0,0,0,0.25)]
+            active:scale-95'
+        />
       </LeftSidebarIcon>
 
       {/* about us */}
       <LeftSidebarIcon title='About Us' selected={selected === 'About Us'} onClick={() => setSelected('About Us')}>
-        <HiUsers className='scale-x-[-1]' size={40} />
+        <HiUsers
+          className='scale-x-[-1] transition-transform duration-300 hover:-translate-x-1 hover:scale-125
+            hover:drop-shadow-[0_0_8px_rgba(0,0,0,0.25)] active:scale-95'
+          size={40}
+        />
       </LeftSidebarIcon>
     </div>
   );

--- a/src/components/navbar/searchbar/history.tsx
+++ b/src/components/navbar/searchbar/history.tsx
@@ -13,12 +13,13 @@ import {
 import { useSearchbar } from './useStore';
 
 const History = () => {
-  const { history, clearHistory } = useSearchbar();
+  const { history, clearHistory, setSearchQuery } = useSearchbar();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          className='dark:hover:bg-dark-green-ergo-navbar rounded-full p-1 transition-colors hover:bg-gray-100'
+          className='dark:hover:bg-dark-green-ergo-navbar cursor-pointer rounded-full p-1 transition-colors
+            hover:bg-gray-100'
           aria-label='Search settings'
         >
           <VscHistory size={28} className='stroke-[0.5px] text-gray-900 dark:text-gray-200' />
@@ -41,11 +42,21 @@ const History = () => {
         )}
 
         {history.map((his, id) => {
-          return <DropdownMenuItem key={id}>{his}</DropdownMenuItem>;
+          return (
+            <DropdownMenuItem
+              onClick={() => {
+                setSearchQuery(his);
+              }}
+              key={id}
+              className='cursor-pointer'
+            >
+              {his}
+            </DropdownMenuItem>
+          );
         })}
 
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={clearHistory}>
+        <DropdownMenuItem onClick={clearHistory} className='cursor-pointer'>
           <span className='text-[11px] text-gray-800 dark:text-gray-300'>Cleaer recent searches</span>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/components/navbar/searchbar/searchbar-input.tsx
+++ b/src/components/navbar/searchbar/searchbar-input.tsx
@@ -13,7 +13,7 @@ const SearchbarInput = () => {
   return (
     <DropdownMenu>
       {/* to avoid changing left space */}
-      <div className='flex items-center'>
+      <div className='flex w-full items-center'>
         {/* standard gap */}
         <div className='flex items-center justify-start gap-0.5'>
           {/* filter components */}

--- a/src/components/navbar/searchbar/searchbar.tsx
+++ b/src/components/navbar/searchbar/searchbar.tsx
@@ -32,7 +32,7 @@ const Searchbar = () => {
               addHistory(searchQuery);
             }}
             size={27}
-            className='text-gray-900 transition-transform duration-300 ease-in-out group-hover:scale-125
+            className='cursor-pointer text-gray-900 transition-transform duration-300 ease-in-out group-hover:scale-125
               dark:text-gray-200'
           />
         </button>

--- a/src/components/navbar/searchbar/searchbar.tsx
+++ b/src/components/navbar/searchbar/searchbar.tsx
@@ -17,7 +17,7 @@ const Searchbar = () => {
         transition-all duration-300 ease-linear dark:border-gray-400 dark:via-gray-900 dark:to-gray-800`}
     >
       {/* history and input area */}
-      <div className='m-3 flex flex-1 items-center'>
+      <div className='m-3 flex w-full flex-1 items-center'>
         <History />
         <div className='m-3 h-6 w-px bg-gray-500'></div>
         {/* input area */}

--- a/src/components/package/package.tsx
+++ b/src/components/package/package.tsx
@@ -18,9 +18,9 @@ const Package = ({ title, assets, authTypes, startDate, endDate, onClick }: Pack
     // container
     <div
       onClick={onClick}
-      className={`${robotoCondensed.className} dark:bg-gray-1000 flex h-[195px] max-w-full min-w-[250px] flex-col
-        overflow-hidden rounded-[18px] border border-gray-500 bg-gray-100 shadow-[-1px_3px_10px_rgba(0,0,0,0.5)]
-        transition-transform dark:border-gray-700`}
+      className={`${robotoCondensed.className} dark:bg-gray-1000 flex h-[195px] max-w-full min-w-[250px] cursor-pointer
+        flex-col overflow-hidden rounded-[18px] border border-gray-500 bg-gray-100
+        shadow-[-1px_3px_10px_rgba(0,0,0,0.5)] transition-transform hover:scale-[1.04] dark:border-gray-700`}
     >
       {/* title */}
       <div

--- a/src/components/pagination/package-pagination.tsx
+++ b/src/components/pagination/package-pagination.tsx
@@ -38,10 +38,10 @@ const PackagePagination = () => {
               aria-label='Previous page'
               onClick={() => decreaseCurrentPage()}
               className={cn(
-                'flex cursor-pointer items-center justify-center rounded-full px-2.5 sm:pl-2.5',
+                'flex items-center justify-center rounded-full px-2.5 sm:pl-2.5',
                 hasPreviousPage
-                  ? 'text-black hover:text-gray-900 dark:text-white'
-                  : 'pointer-events-none text-gray-700 dark:text-gray-500',
+                  ? 'cursor-pointer text-black hover:text-gray-900 dark:text-white'
+                  : 'cursor-not-allowed text-gray-700 dark:text-gray-500',
               )}
             >
               <ChevronLeftIcon />
@@ -57,10 +57,10 @@ const PackagePagination = () => {
               aria-label='Next page'
               onClick={() => increaseCurrentPage()}
               className={cn(
-                'flex cursor-pointer items-center justify-center rounded-full px-2.5 sm:pl-2.5',
+                'flex items-center justify-center rounded-full px-2.5 sm:pl-2.5',
                 hasNextPage
-                  ? 'text-black hover:text-gray-900 dark:text-white'
-                  : 'pointer-events-none text-gray-700 dark:text-gray-500',
+                  ? 'cursor-pointer text-black hover:text-gray-900 dark:text-white'
+                  : 'cursor-not-allowed text-gray-700 dark:text-gray-500',
               )}
             >
               <ChevronRightIcon />

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -67,9 +67,10 @@ function DropdownMenuItem({
         `focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive
         data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20
         data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive
-        [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm
-        px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50
-        data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
+        [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default cursor-pointer items-center
+        gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none
+        data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0
+        [&_svg:not([class*='size-'])]:size-4`,
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -110,7 +110,7 @@ function SelectItem({ className, children, ...props }: React.ComponentProps<type
       data-slot='select-item'
       className={cn(
         `focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex
-        w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none
+        w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none
         data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0
         [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2`,
         className,


### PR DESCRIPTION
shadow & scale on hover:
<img width="110" height="388" alt="image" src="https://github.com/user-attachments/assets/2303c075-506b-40c9-af45-69d1c1cdca46" />
selected is green
shadow & flip & scale on hover:
<img width="109" height="351" alt="image" src="https://github.com/user-attachments/assets/951232bc-8aa3-45c6-a291-6a76607aa772" />

cancel button works now:
<img width="557" height="274" alt="image" src="https://github.com/user-attachments/assets/c93b6715-f778-44e9-bfe3-9ffc6e246833" />
claimng closes the modal now:
<img width="517" height="151" alt="image" src="https://github.com/user-attachments/assets/61259d5b-9c1f-45ae-96ac-fcad288686b7" />



- cursor not allowed when no previous/next page is available: 
<img width="334" height="106" alt="image" src="https://github.com/user-attachments/assets/7fce6cb2-cd95-4e1c-81de-8d49f399616e" />

- searchbar interactions
- set searchbar text when selected from the history
<img width="783" height="253" alt="image" src="https://github.com/user-attachments/assets/0e8f4a45-d418-40e1-a963-dae78e071bc1" />


- cursor-pointer on hover
<img width="185" height="277" alt="image" src="https://github.com/user-attachments/assets/18727f64-0a59-4721-a235-6b7cc637c75f" />

- cursor-pointer & scale on hover
<img width="866" height="459" alt="image" src="https://github.com/user-attachments/assets/e3fdecec-3f89-4ff3-a536-1f6b19d77c28" />
